### PR TITLE
Fix dead link.

### DIFF
--- a/newton-faq-nos.html
+++ b/newton-faq-nos.html
@@ -604,7 +604,7 @@
 <hr />
 <h3 id="IIIC">C) Troubleshooting</h3>
 <h4 id="IIIC1">1) Is the Newton Y2K compliant?</h4>
-<p>Apparently so: <a href="http://docs.info.apple.com/article.html?orig=til&amp;artnum=30338">http://docs.info.apple.com/article.html?orig=til&amp;artnum=30338</a></p>
+<p>Apparently so: <a href="https://web.archive.org/web/20021001190009/http://docs.info.apple.com/article.html?orig=til&amp;artnum=30338">https://web.archive.org/web/20021001190009/http://docs.info.apple.com/article.html?orig=til&amp;artnum=30338</a></p>
 <p>However, different date and time related problems might occur starting in 2010, 2099 and 2924 (should you be so lucky to be alive, with a functioning Newton). These problems are discussed on Steve Weyer’s page, <a href="https://communicrossings.com/html/newton/newtscape/exs/times.htm">The Times, They Are a Changin’</a>.</p>
 <p>Avi Drissman created <a href="http://www.drissman.com/avi/newton/Fix2010/">an experimental fix</a> for the Year 2010 problem.</p>
 


### PR DESCRIPTION
From Alan Grassia <alan.grassia@gmail.com>, via NewtonTalk

I was reading the Newton FAQ site and found some link rot to the Apple website for the Y2K compliance statement.  I know, we’re a bit beyond Y2K, but for completeness, I figured an updated link would be nice.